### PR TITLE
Add instruction on where to create the CFN stack

### DIFF
--- a/7-MediaConvertJobLambda/README.md
+++ b/7-MediaConvertJobLambda/README.md
@@ -16,7 +16,7 @@ Converted outputs will be saved in the S3 MediaBucket created in earlier in the 
 
 Each of the following sections provide an implementation overview and detailed, step-by-step instructions. The overview should provide enough context for you to complete the implementation if you're already familiar with the AWS Management Console or you want to explore the services yourself without following a walkthrough.
 
-A cloudformation template is provided for this module in the file `WatchFolder.yaml`, if you would prefer to build the automated workflow automatically.
+A CloudFormation template is provided for this module in the file `WatchFolder.yaml`, if you would prefer to build the automated workflow automatically. **Note:** Run the CloudFormation template in us-west-2.
 
 ### 1. Create an Amazon S3 bucket to use for uploading videos to be converted
 


### PR DESCRIPTION
The account that owns the buckets named rodeolabz-[region] hasn't created them in all the regions where MediaConvert is. I've only found us-west-2 to have this bucket and lambda function available. 

All the other regions where you try and run the CFN stack give errors stating no such key or no such bucket.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
