### PR TITLE
PassRolestoMediaConvert Sid was

### DIFF
--- a/1-IAMandS3/README-user.md
+++ b/1-IAMandS3/README-user.md
@@ -32,7 +32,7 @@ Create an IAM Policy and name it `vod-MediaConvertUserPolicy`.  Use inline polic
                 "iam:PassRole"
             ],
             "Effect": "Allow",
-            "Resource": "arn:aws:iam::*"
+            "Resource": "*"
         },
         {
             "Sid": "ListWriteS3Buckets",


### PR DESCRIPTION
Using this was giving me the error `This policy contains the following error: The following resources are invalid. They must be either '*' or an arn pattern: arn:aws:iam::*`,  for the `PassRolestoMediaConvert` `Sid`. 

Your version does have the `arn:aws:iam::*` pattern, but I couldn't save the role until I changed this to `*`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
