### PR TITLE
Update MediaConvertIAMandS3.yaml

### DIFF
--- a/1-IAMandS3/MediaConvertIAMandS3.yaml
+++ b/1-IAMandS3/MediaConvertIAMandS3.yaml
@@ -81,6 +81,11 @@ Resources:
         - Id: ExpireRule
           Status: Enabled
           ExpirationInDays: '7'
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
     DeletionPolicy: Retain
     Type: "AWS::S3::Bucket"
 


### PR DESCRIPTION
Prevent the access denied caused by Block Public Access.

*Issue #, if available:* N/A

*Description of changes:* The bucket cannot be created. After tests, I noticed that the error might due to default block public access settings. After modifying CloudFormation template, I can run the stack.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
